### PR TITLE
Start shim v2 implementation - Milestone 1 setup

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,6 @@ jobs:
           path: target/release/
 
   kind-integration:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -58,17 +57,10 @@ jobs:
         with:
           version: "v1.30.0"
 
-      - name: Download release binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: release-binaries
-          path: target/release/
-
       - name: Run kind integration tests
         run: |
-          # Make binaries executable and prepare for integration test
-          chmod +x target/release/reaper-runtime target/release/containerd-shim-reaper-v2
           chmod +x scripts/kind-integration.sh
 
           # Run the shared integration test script
+          # Note: The script builds static musl binaries for kind node compatibility
           ./scripts/kind-integration.sh


### PR DESCRIPTION
- Add design document: docs/SHIMV2_DESIGN.md
- Create containerd-shim-reaper-v2 binary skeleton
- Add dependencies: tokio, async-trait, ttrpc, protobuf
- Initial main.rs with logging setup
- All compiles successfully

Next: Implement TTRPC server and Task service