### PR TITLE
feat: add git-cliff changelog generation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for release loop
         id: loop-guard
@@ -77,12 +77,20 @@ jobs:
             exit 1
           fi
 
+      - name: Install git-cliff
+        if: steps.loop-guard.outputs.skip != 'true'
+        uses: kenji-miyake/setup-git-cliff@v2
+
+      - name: Generate changelog
+        if: steps.loop-guard.outputs.skip != 'true'
+        run: git-cliff --tag "v${{ steps.bump.outputs.version }}" -o CHANGELOG.md
+
       - name: Commit, tag, and push
         if: steps.loop-guard.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock
+          git add Cargo.toml Cargo.lock CHANGELOG.md
           git commit -m "chore(release): v${{ steps.bump.outputs.version }} [skip ci]"
           git tag -a "v${{ steps.bump.outputs.version }}" -m "Release v${{ steps.bump.outputs.version }}"
           git push origin main --follow-tags

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -81,6 +82,12 @@ jobs:
             exit 1
           fi
 
+      - name: Install git-cliff
+        uses: kenji-miyake/setup-git-cliff@v2
+
+      - name: Generate changelog
+        run: git-cliff --tag "v${{ steps.bump.outputs.version }}" -o CHANGELOG.md
+
       - name: Show diff (dry run)
         if: inputs.dry_run
         run: |
@@ -93,7 +100,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock
+          git add Cargo.toml Cargo.lock CHANGELOG.md
           git commit -m "chore(release): v${{ steps.bump.outputs.version }} [skip ci]"
           git tag -a "v${{ steps.bump.outputs.version }}" -m "Release v${{ steps.bump.outputs.version }}"
           git push origin main --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,20 @@ jobs:
       id-token: write  # Required for cosign keyless signing via GitHub OIDC
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install git-cliff
+        uses: kenji-miyake/setup-git-cliff@v2
+
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          {
+            echo 'BODY<<EOF'
+            git-cliff --latest --strip header
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -117,7 +131,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body: ${{ steps.release-notes.outputs.BODY }}
           files: |
             artifacts/*.tar.gz
             artifacts/checksums-sha256.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,152 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-02-18
+
+### Features
+
+- Versioning, release pipeline, and install-from-release  (29262c2)
+- Add playground setup script and fix PTY exit handling  (e994dda)
+- Add volume mount support for Kubernetes volumes  (e6b557f)
+- Implement UID/GID switching with privilege dropping  (07cf0ae)
+- Add sensitive file filtering to overlay filesystem  (49035f0)
+- Unify deployment with Ansible for both Kind and production (34c2887)
+- Implement Phase 2 - Ansible playbooks for production deployment (16fdd72)
+- Implement core install-reaper.sh script (44d368b)
+- Add Makefile for CI-parity development workflow (3f8a0df)
+- Add commit id and timestamp to integration test output (30be322)
+- Add integration test to validate defunct procs (5dc8941)
+- Add PTY/terminal support for interactive containers + exec implementation\n\n- Add terminal flag to ContainerState and pass --terminal from shim to runtime\n- Implement PTY allocation in do_start() when terminal=true (kubectl run -it)\n- Relay stdin FIFO → PTY master and PTY master → stdout FIFO for interactive I/O\n- Add exec lifecycle: exec state management, exec_with_pty, exec_without_pty\n- Add exec integration tests and EXEC_IMPLEMENTATION_PLAN.md\n- Update kind-integration.sh and Cargo.toml\n- Remove CLAUDE.MD files (8847a4e)
+- Add shared mount namespace with overlayfs for host protection (4ff7a89)
+- Implement container stdout/stderr capture for kubectl logs integration (1bd4b32)
+- Complete Milestone 5 - Kubernetes Integration (78b495b)
+- Start Milestone 4 - Advanced Features (7614708)
+- Implement Milestone 3 - Direct Command Execution (edde35e)
+- Add unit tests for state module, refactor runtime CLI, build musl binary for minikube (abc9396)
+- **runtime**: Scaffold minimal OCI-like runtime CLI for containerd (create/start/state/kill/delete) with basic state store (69f25a7)
+
+### Bug Fixes
+
+- ECHILD race, 14 new integration tests, test script refactoring  (d8d19fe)
+- Pod stuck in Terminating due to missing setsid() in non-terminal mode  (183c246)
+- Correct GitHub username in README badges  (d417f85)
+- Use CI-safe binary path to avoid permission issues in GitHub Actions (017aa93)
+- Ansible installer compatibility and script syntax errors (c002cde)
+- Override ANSIBLE_STDOUT_CALLBACK environment variable (4b9f7e3)
+- Add ansible.cfg for cross-version compatibility (2602594)
+- Build static musl binaries for Kind and show Ansible errors (b63de5a)
+- Build binaries before Ansible installer in integration tests (06eda60)
+- Skip overlay integration tests when namespace support unavailable (dc59cff)
+- Serialize overlay config tests with mutex to prevent race conditions (7f8bfa3)
+- Ensure proper test isolation for overlay config tests (56f654c)
+- Show detailed diagnostics when integration tests fail (e1fe093)
+- Skip overlay in unit tests and fix clippy warnings (74c3cc9)
+- Use temp directories for overlay paths in integration tests (6aedb5b)
+- Increase PID polling timeout on Linux and add overlay debug logging (958f6e9)
+- Signal ExitSignal in shutdown() so shim processes exit (d4e8c74)
+- Reap zombie monitoring daemons in shim (afb4d2e)
+- Use c_ulong for TIOCSCTTY ioctl request type on all platforms (e161686)
+- Make DNS check pod always succeed in kind-integration.sh (e3a601d)
+- Prevent zombie processes by reaping daemon in do_start() (8a3944b)
+- Increase workload wait() timeout from 60s to 1h\n\nThe 60-second polling timeout in the shim's wait() was causing\ninteractive containers (kubectl run -it) to be killed after ~1 minute.\nIncreased to 1 hour to match the exec wait timeout. (28c13c7)
+- Enforce overlay isolation - remove /tmp bind-mount and make overlay mandatory (d8bd982)
+- Resolve libc dependency and unused variable in overlay tests (e390f2b)
+- Use as_raw_fd() for nix::unistd::read which still expects RawFd (c9b70b4)
+- Update overlay module for nix 0.28 API compatibility (1eaf46b)
+- Update all packages (d13b8e9)
+- Update bytes crate to 1.11.1 for RUSTSEC-2026-0007 (e10d615)
+- Sandbox wait() blocking, PID race condition, and stale pod cleanup (af8f4cb)
+- Return STOPPED status for sandbox containers to enable pod cleanup (2202f08)
+- Add 5s timeout to kill() method to prevent pod cleanup hangs (b159d2b)
+- Add 30s timeout to wait() polling loop to prevent pod cleanup hangs (e79796a)
+- Simplify grep pattern to be more robust (f74ef7e)
+- Use precise line deletion for reaper-v2 removal (bb06e75)
+- Correct grep pattern for runc section matching (2b018fe)
+- Make reaper-v2 deletion more precise to preserve runc section (228a88f)
+- Remove duplicate reaper-v2 sections to prevent TOML parse errors (3c150e2)
+- Use minimal containerd config for kind to resolve control plane instability (2bc7e7c)
+- Resolve zombie process accumulation in reaper shim (d43e94f)
+- Ensure static musl binaries for kind to avoid glibc version mismatch (6e164b9)
+- Add retry logic and enhanced logging to kind integration tests (b39f56a)
+- Add service account wait and project documentation for CI (cd1bbb7)
+- Build Linux binaries for kind cluster testing (d3cebb4)
+- Update kind integration setup for proper reaper-v2 configuration (5a18ccf)
+- Update test_config_with_root_user to reflect disabled user switching (3dbc29d)
+- Integration workflow - wait for API server and handle validation errors (0682643)
+- Integration workflow - fix containerd config directory and improve error handling (7e14998)
+- Fix clippy (a233ba4)
+- Resolve unused CommandStatus::Stopped warning (fb2773c)
+- Remove src/ from gitignore, add src/main.rs, remove Windows from CI (c6573fe)
+
+### Refactoring
+
+- Use Makefile for building binaries in integration tests (b6f5a03)
+- Complete migration to unified Ansible installer (11d24ac)
+- Use install-reaper.sh in integration test suite (041d7b3)
+- Consolidate integration tests and scripts into common locations (e3721d2)
+- Replace kind-integration.sh with structured test harness (7eb03cf)
+- Improve DNS validation in kind-integration.sh (95dbb67)
+- Preserve kind-generated containerd config and extend with sed (79dbf3a)
+- Use sed-based configuration for kind containerd setup (f1ad843)
+- Consolidate coverage into test workflow to eliminate redundant builds (4025607)
+- Optimize coverage workflow with build job and cache sharing (c5547fb)
+- Implement proper OCI shim architecture invoking reaper-runtime (a3ab6a3)
+
+### Documentation
+
+- Reorganize documentation for better user experience (8e55744)
+- Document CRD evaluation done (758335a)
+- Add CLAUDE.md with CI/CD and integration testing context (49da7ab)
+- Update progress tracker to reflect Ansible approach (e8098fc)
+- Revise Phase 2 to use Ansible instead of DaemonSet (4b42d65)
+- Update documentation for install-reaper.sh (c260f55)
+- Add installation script implementation plan (b30bd03)
+- Update documentation to reflect recent changes (exec, PTY, overlay improvements) (3ad5580)
+- Mark Milestone 5 as completed and update next steps (221d845)
+- Update SHIMV2_DESIGN.md to reflect Milestone 3 completion (01edc73)
+- Update SHIMV2_DESIGN.md with current implementation status (6a68f5a)
+- Clarify OCI allows root processes (uid=0) (fbdb1ec)
+- Document uid/gid requirements for OCI compatibility (6099e29)
+- Clarify stdout/stderr handling (7f4cc19)
+- Document integration tests for core binary execution (ca6cf88)
+- Clarify reaper-runtime usage and Kubernetes integration status (25e9a1a)
+- **runtime**: Document reaper-runtime CLI, containerd config, and Kubernetes RuntimeClass example (7a80005)
+- Add CI badges and clarify Docker usage; fix coverage container networking (6ada821)
+
+### Testing
+
+- Improve unit test coverage and lower tarpaulin threshold (b2a634d)
+- Parameterize ensure_etc_files_in_namespace and add unit tests (d9ac1d6)
+- Add unit tests for overlay helper functions to improve coverage (f481abe)
+- Add end-to-end Kubernetes integration test script (1f26135)
+- Add integration tests for containerd shim v2 (8e0ca2d)
+- **integration**: Add core binary execution tests (2099b07)
+- **integration**: Add minikube and kind integration scripts and CI workflow for runtime validation (95375c3)
+
+### CI/CD
+
+- Add comprehensive log capture and artifact upload to integration workflow (3d5b266)
+- Remove doc tests (binary-only crate); update README CI section (c3d8afc)
+- **coverage**: Enforce 75% minimum and fail on Codecov upload errors (c1c0913)
+- Add Codecov token to coverage workflow (75d5b2a)
+- Run cargo-audit in build workflow; document audit in README (1a96f59)
+
+### Reverts
+
+- Sandbox status change breaks container initialization (e55b3aa)
+
+### Miscellaneous
+
+- Declutter repo root directory structure  (8ced09d)
+- Add cobertura.xml to gitignore (28608b5)
+- Add comprehensive logging and debugging output to integration test (b5d79e6)
+- Increase wait() timeout to 60s and slow kubectl polling to 5s intervals (8f78d6f)
+- Update GitHub Actions artifact actions from v3 to v4 (12a6e5a)
+- Improve doc (a3afda1)
+- Remove target-linux from git tracking (6d4789e)
+- Remove accidental extra state modules (f4ca852)
+

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,68 @@
+# git-cliff configuration
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+# changelog header
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+# template for the changelog body
+body = """
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim }}
+{% for commit in commits %}
+- {% if commit.scope %}**{{ commit.scope }}**: {% endif %}\
+  {{ commit.message | upper_first }} ({{ commit.id | truncate(length=7, end="") }})\
+{%- endfor %}
+{% endfor %}
+"""
+# template for the changelog footer
+footer = ""
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+  # remove issue numbers from commits
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+]
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->Features" },
+  { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
+  { message = "^perf", group = "<!-- 2 -->Performance" },
+  { message = "^refactor", group = "<!-- 3 -->Refactoring" },
+  { message = "^doc", group = "<!-- 4 -->Documentation" },
+  { message = "^test", group = "<!-- 5 -->Testing" },
+  { message = "^ci", group = "<!-- 6 -->CI/CD" },
+  { message = "^revert", group = "<!-- 7 -->Reverts" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore|^style|^improve", group = "<!-- 8 -->Miscellaneous" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = true
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"


### PR DESCRIPTION
## Summary
- Add `cliff.toml` configuration for git-cliff with conventional commit parsing and categorized sections (Features, Bug Fixes, Performance, Refactoring, Documentation, Testing, CI/CD, Reverts, Miscellaneous)
- Integrate git-cliff into `auto-release.yml` and `manual-release.yml` to update `CHANGELOG.md` on each release commit
- Replace GitHub's `generate_release_notes: true` in `release.yml` with git-cliff output for structured release notes on GitHub Releases
- Generate initial `CHANGELOG.md` from existing commit history

## Test plan
- [ ] Verify `manual-release.yml` dry-run shows CHANGELOG.md in the diff
- [ ] Trigger a manual release and confirm CHANGELOG.md is updated in the release commit
- [ ] Confirm GitHub Release page shows categorized release notes from git-cliff

🤖 Generated with [Claude Code](https://claude.com/claude-code)