### PR TITLE
feat: add Kubernetes DNS support and unify example setup scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Host Root (/) ─── read-only lower layer
 
 **Configuration:**
 - `REAPER_OVERLAY_BASE`: Default `/run/reaper/overlay`
+- `REAPER_DNS_MODE`: DNS resolution mode — `host` (default) uses node's resolv.conf, `kubernetes`/`k8s` writes kubelet-prepared resolv.conf (pointing to CoreDNS) into the overlay
 - Overlay is mandatory on Linux (no fail-open)
 - Not available on macOS (code gated with `#[cfg(target_os = "linux")]`)
 

--- a/deploy/ansible/install-reaper.yml
+++ b/deploy/ansible/install-reaper.yml
@@ -151,6 +151,14 @@
         create: yes
         mode: '0644'
 
+    - name: Set Reaper DNS mode for containerd
+      lineinfile:
+        path: /etc/default/containerd
+        line: "REAPER_DNS_MODE={{ reaper_dns_mode | default('kubernetes') }}"
+        regexp: "^REAPER_DNS_MODE="
+        create: yes
+        mode: '0644'
+
     - name: Ensure containerd service picks up environment file
       shell: |
         mkdir -p /etc/systemd/system/containerd.service.d

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,4 +15,4 @@ List of tasks to do, not ordered in any specific way.
 - [x] Add complex example (idea openldap server + sssd + something that uses users)
 - [x] Add quick-start guide with a playground kind cluster for doing fast testing
 - [ ] Evaluate if it would make sense to isolate overlays by namespace
-- [ ] Manage DNS settings, currently relying on host DNS instead of k8s DNS settings.
+- [x] Manage DNS settings, currently relying on host DNS instead of k8s DNS settings.

--- a/examples/01-scheduling/setup.sh
+++ b/examples/01-scheduling/setup.sh
@@ -41,6 +41,24 @@ warn()  { echo " ${Y}!!${R}  $*"; }
 fail()  { echo " ${Y}ERR${R} $*" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  echo "Usage: $0 [VERSION] [OPTIONS]"
+  echo ""
+  echo "Create a 3-node Kind cluster with Reaper installed and node labels."
+  echo ""
+  echo "Arguments:"
+  echo "  VERSION      Release version to install (e.g., v0.2.5). Default: latest"
+  echo ""
+  echo "Options:"
+  echo "  --build      Build binaries from source instead of downloading a release"
+  echo "  --cleanup    Delete the Kind cluster"
+  echo "  -h, --help   Show this help message"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Cleanup mode
 # ---------------------------------------------------------------------------
 if [[ "${1:-}" == "--cleanup" ]]; then
@@ -48,6 +66,20 @@ if [[ "${1:-}" == "--cleanup" ]]; then
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null && ok "Cluster deleted." || warn "Cluster not found."
   exit 0
 fi
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+BUILD_MODE=false
+RELEASE_VERSION="latest"
+
+for arg in "$@"; do
+  case "$arg" in
+    --build)   BUILD_MODE=true ;;
+    --cleanup|--help|-h) ;;  # already handled above
+    *)         RELEASE_VERSION="$arg" ;;
+  esac
+done
 
 # ---------------------------------------------------------------------------
 # Preflight checks
@@ -65,6 +97,23 @@ if [[ ! -f "$REPO_ROOT/scripts/install-reaper.sh" ]]; then
 fi
 
 ok "All prerequisites found."
+
+# ---------------------------------------------------------------------------
+# Resolve release version
+# ---------------------------------------------------------------------------
+if ! $BUILD_MODE; then
+  # shellcheck source=../../scripts/lib/release-utils.sh
+  source "$REPO_ROOT/scripts/lib/release-utils.sh"
+
+  if [[ "$RELEASE_VERSION" == "latest" ]]; then
+    info "Resolving latest release..."
+    RELEASE_VERSION=$(resolve_latest_release) || \
+      fail "Could not determine latest release. Specify a version or use --build."
+    ok "Latest release: $RELEASE_VERSION"
+  else
+    ok "Using release: $RELEASE_VERSION"
+  fi
+fi
 
 # ---------------------------------------------------------------------------
 # Create Kind config for 3 nodes (1 control-plane + 2 workers)
@@ -95,55 +144,61 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Build static musl binaries for Kind nodes
+# Install Reaper on all nodes
 # ---------------------------------------------------------------------------
-info "Building Reaper binaries for Kind nodes"
+if $BUILD_MODE; then
+  info "Building Reaper binaries for Kind nodes"
+
+  cd "$REPO_ROOT"
+
+  NODE_ID=$(docker ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.ID}}')
+  NODE_ARCH=$(docker exec "$NODE_ID" uname -m 2>&1) || fail "Cannot detect node architecture"
+
+  case "$NODE_ARCH" in
+    aarch64)
+      TARGET_TRIPLE="aarch64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:aarch64-musl"
+      ;;
+    x86_64)
+      TARGET_TRIPLE="x86_64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:x86_64-musl"
+      ;;
+    *)
+      fail "Unsupported architecture: $NODE_ARCH"
+      ;;
+  esac
+
+  echo "  Architecture: $NODE_ARCH ($TARGET_TRIPLE)"
+
+  docker run --rm \
+    -v "$(pwd)":/work \
+    -w /work \
+    "$MUSL_IMAGE" \
+    cargo build --release \
+      --bin containerd-shim-reaper-v2 \
+      --bin reaper-runtime \
+      --target "$TARGET_TRIPLE" \
+    >> "$LOG_FILE" 2>&1 || {
+      fail "Build failed. See $LOG_FILE for details."
+    }
+
+  mkdir -p target/release
+  cp "target/$TARGET_TRIPLE/release/containerd-shim-reaper-v2" target/release/
+  cp "target/$TARGET_TRIPLE/release/reaper-runtime" target/release/
+
+  ok "Binaries built."
+fi
+
+info "Installing Reaper on all nodes"
 
 cd "$REPO_ROOT"
 
-NODE_ID=$(docker ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.ID}}')
-NODE_ARCH=$(docker exec "$NODE_ID" uname -m 2>&1) || fail "Cannot detect node architecture"
+INSTALL_ARGS=(--kind "$CLUSTER_NAME")
+if ! $BUILD_MODE; then
+  INSTALL_ARGS+=(--release "$RELEASE_VERSION")
+fi
 
-case "$NODE_ARCH" in
-  aarch64)
-    TARGET_TRIPLE="aarch64-unknown-linux-musl"
-    MUSL_IMAGE="messense/rust-musl-cross:aarch64-musl"
-    ;;
-  x86_64)
-    TARGET_TRIPLE="x86_64-unknown-linux-musl"
-    MUSL_IMAGE="messense/rust-musl-cross:x86_64-musl"
-    ;;
-  *)
-    fail "Unsupported architecture: $NODE_ARCH"
-    ;;
-esac
-
-echo "  Architecture: $NODE_ARCH ($TARGET_TRIPLE)"
-
-docker run --rm \
-  -v "$(pwd)":/work \
-  -w /work \
-  "$MUSL_IMAGE" \
-  cargo build --release \
-    --bin containerd-shim-reaper-v2 \
-    --bin reaper-runtime \
-    --target "$TARGET_TRIPLE" \
-  >> "$LOG_FILE" 2>&1 || {
-    fail "Build failed. See $LOG_FILE for details."
-  }
-
-mkdir -p target/release
-cp "target/$TARGET_TRIPLE/release/containerd-shim-reaper-v2" target/release/
-cp "target/$TARGET_TRIPLE/release/reaper-runtime" target/release/
-
-ok "Binaries built."
-
-# ---------------------------------------------------------------------------
-# Install Reaper on all nodes via Ansible
-# ---------------------------------------------------------------------------
-info "Installing Reaper runtime on all nodes"
-
-./scripts/install-reaper.sh --kind "$CLUSTER_NAME" >> "$LOG_FILE" 2>&1 || {
+./scripts/install-reaper.sh "${INSTALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 || {
   fail "Ansible install failed. See $LOG_FILE for details."
 }
 
@@ -200,6 +255,12 @@ echo "${C}========================================${R}"
 echo "${B}Cluster ready: $CLUSTER_NAME${R}"
 echo "${C}========================================${R}"
 echo ""
+
+if ! $BUILD_MODE; then
+  echo "${B}Reaper release: $RELEASE_VERSION${R}"
+else
+  echo "${B}Reaper: built from source${R}"
+fi
 
 echo "${B}Nodes:${R}"
 kubectl get nodes -o custom-columns=\

--- a/examples/02-client-server/setup.sh
+++ b/examples/02-client-server/setup.sh
@@ -47,6 +47,24 @@ warn()  { echo " ${Y}!!${R}  $*"; }
 fail()  { echo " ${Y}ERR${R} $*" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  echo "Usage: $0 [VERSION] [OPTIONS]"
+  echo ""
+  echo "Create a 3-node Kind cluster for the client-server demo."
+  echo ""
+  echo "Arguments:"
+  echo "  VERSION      Release version to install (e.g., v0.2.5). Default: latest"
+  echo ""
+  echo "Options:"
+  echo "  --build      Build binaries from source instead of downloading a release"
+  echo "  --cleanup    Delete the Kind cluster"
+  echo "  -h, --help   Show this help message"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Cleanup mode
 # ---------------------------------------------------------------------------
 if [[ "${1:-}" == "--cleanup" ]]; then
@@ -55,6 +73,20 @@ if [[ "${1:-}" == "--cleanup" ]]; then
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null && ok "Cluster deleted." || warn "Cluster not found."
   exit 0
 fi
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+BUILD_MODE=false
+RELEASE_VERSION="latest"
+
+for arg in "$@"; do
+  case "$arg" in
+    --build)   BUILD_MODE=true ;;
+    --cleanup|--help|-h) ;;  # already handled above
+    *)         RELEASE_VERSION="$arg" ;;
+  esac
+done
 
 # ---------------------------------------------------------------------------
 # Preflight checks
@@ -72,6 +104,23 @@ if [[ ! -f "$REPO_ROOT/scripts/install-reaper.sh" ]]; then
 fi
 
 ok "All prerequisites found."
+
+# ---------------------------------------------------------------------------
+# Resolve release version
+# ---------------------------------------------------------------------------
+if ! $BUILD_MODE; then
+  # shellcheck source=../../scripts/lib/release-utils.sh
+  source "$REPO_ROOT/scripts/lib/release-utils.sh"
+
+  if [[ "$RELEASE_VERSION" == "latest" ]]; then
+    info "Resolving latest release..."
+    RELEASE_VERSION=$(resolve_latest_release) || \
+      fail "Could not determine latest release. Specify a version or use --build."
+    ok "Latest release: $RELEASE_VERSION"
+  else
+    ok "Using release: $RELEASE_VERSION"
+  fi
+fi
 
 # ---------------------------------------------------------------------------
 # Create Kind config for 4 nodes (1 control-plane + 3 workers)
@@ -103,55 +152,61 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Build static musl binaries for Kind nodes
+# Install Reaper on all nodes
 # ---------------------------------------------------------------------------
-info "Building Reaper binaries for Kind nodes"
+if $BUILD_MODE; then
+  info "Building Reaper binaries for Kind nodes"
+
+  cd "$REPO_ROOT"
+
+  NODE_ID=$(docker ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.ID}}')
+  NODE_ARCH=$(docker exec "$NODE_ID" uname -m 2>&1) || fail "Cannot detect node architecture"
+
+  case "$NODE_ARCH" in
+    aarch64)
+      TARGET_TRIPLE="aarch64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:aarch64-musl"
+      ;;
+    x86_64)
+      TARGET_TRIPLE="x86_64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:x86_64-musl"
+      ;;
+    *)
+      fail "Unsupported architecture: $NODE_ARCH"
+      ;;
+  esac
+
+  echo "  Architecture: $NODE_ARCH ($TARGET_TRIPLE)"
+
+  docker run --rm \
+    -v "$(pwd)":/work \
+    -w /work \
+    "$MUSL_IMAGE" \
+    cargo build --release \
+      --bin containerd-shim-reaper-v2 \
+      --bin reaper-runtime \
+      --target "$TARGET_TRIPLE" \
+    >> "$LOG_FILE" 2>&1 || {
+      fail "Build failed. See $LOG_FILE for details."
+    }
+
+  mkdir -p target/release
+  cp "target/$TARGET_TRIPLE/release/containerd-shim-reaper-v2" target/release/
+  cp "target/$TARGET_TRIPLE/release/reaper-runtime" target/release/
+
+  ok "Binaries built."
+fi
+
+info "Installing Reaper on all nodes"
 
 cd "$REPO_ROOT"
 
-NODE_ID=$(docker ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.ID}}')
-NODE_ARCH=$(docker exec "$NODE_ID" uname -m 2>&1) || fail "Cannot detect node architecture"
+INSTALL_ARGS=(--kind "$CLUSTER_NAME")
+if ! $BUILD_MODE; then
+  INSTALL_ARGS+=(--release "$RELEASE_VERSION")
+fi
 
-case "$NODE_ARCH" in
-  aarch64)
-    TARGET_TRIPLE="aarch64-unknown-linux-musl"
-    MUSL_IMAGE="messense/rust-musl-cross:aarch64-musl"
-    ;;
-  x86_64)
-    TARGET_TRIPLE="x86_64-unknown-linux-musl"
-    MUSL_IMAGE="messense/rust-musl-cross:x86_64-musl"
-    ;;
-  *)
-    fail "Unsupported architecture: $NODE_ARCH"
-    ;;
-esac
-
-echo "  Architecture: $NODE_ARCH ($TARGET_TRIPLE)"
-
-docker run --rm \
-  -v "$(pwd)":/work \
-  -w /work \
-  "$MUSL_IMAGE" \
-  cargo build --release \
-    --bin containerd-shim-reaper-v2 \
-    --bin reaper-runtime \
-    --target "$TARGET_TRIPLE" \
-  >> "$LOG_FILE" 2>&1 || {
-    fail "Build failed. See $LOG_FILE for details."
-  }
-
-mkdir -p target/release
-cp "target/$TARGET_TRIPLE/release/containerd-shim-reaper-v2" target/release/
-cp "target/$TARGET_TRIPLE/release/reaper-runtime" target/release/
-
-ok "Binaries built."
-
-# ---------------------------------------------------------------------------
-# Install Reaper on all nodes via Ansible
-# ---------------------------------------------------------------------------
-info "Installing Reaper runtime on all nodes"
-
-./scripts/install-reaper.sh --kind "$CLUSTER_NAME" >> "$LOG_FILE" 2>&1 || {
+./scripts/install-reaper.sh "${INSTALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 || {
   fail "Ansible install failed. See $LOG_FILE for details."
 }
 
@@ -246,6 +301,12 @@ echo "${C}========================================${R}"
 echo "${B}Cluster ready: $CLUSTER_NAME${R}"
 echo "${C}========================================${R}"
 echo ""
+
+if ! $BUILD_MODE; then
+  echo "${B}Reaper release: $RELEASE_VERSION${R}"
+else
+  echo "${B}Reaper: built from source${R}"
+fi
 
 echo "${B}Nodes:${R}"
 kubectl get nodes -o custom-columns=\

--- a/examples/04-volumes/setup.sh
+++ b/examples/04-volumes/setup.sh
@@ -50,6 +50,24 @@ warn()  { echo " ${Y}!!${R}  $*"; }
 fail()  { echo " ${Y}ERR${R} $*" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  echo "Usage: $0 [VERSION] [OPTIONS]"
+  echo ""
+  echo "Create a 2-node Kind cluster for the volumes demo."
+  echo ""
+  echo "Arguments:"
+  echo "  VERSION      Release version to install (e.g., v0.2.5). Default: latest"
+  echo ""
+  echo "Options:"
+  echo "  --build      Build binaries from source instead of downloading a release"
+  echo "  --cleanup    Delete the Kind cluster"
+  echo "  -h, --help   Show this help message"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Cleanup mode
 # ---------------------------------------------------------------------------
 if [[ "${1:-}" == "--cleanup" ]]; then
@@ -59,6 +77,20 @@ if [[ "${1:-}" == "--cleanup" ]]; then
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null && ok "Cluster deleted." || warn "Cluster not found."
   exit 0
 fi
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+BUILD_MODE=false
+RELEASE_VERSION="latest"
+
+for arg in "$@"; do
+  case "$arg" in
+    --build)   BUILD_MODE=true ;;
+    --cleanup|--help|-h) ;;  # already handled above
+    *)         RELEASE_VERSION="$arg" ;;
+  esac
+done
 
 # ---------------------------------------------------------------------------
 # Preflight checks
@@ -76,6 +108,23 @@ if [[ ! -f "$REPO_ROOT/scripts/install-reaper.sh" ]]; then
 fi
 
 ok "All prerequisites found."
+
+# ---------------------------------------------------------------------------
+# Resolve release version
+# ---------------------------------------------------------------------------
+if ! $BUILD_MODE; then
+  # shellcheck source=../../scripts/lib/release-utils.sh
+  source "$REPO_ROOT/scripts/lib/release-utils.sh"
+
+  if [[ "$RELEASE_VERSION" == "latest" ]]; then
+    info "Resolving latest release..."
+    RELEASE_VERSION=$(resolve_latest_release) || \
+      fail "Could not determine latest release. Specify a version or use --build."
+    ok "Latest release: $RELEASE_VERSION"
+  else
+    ok "Using release: $RELEASE_VERSION"
+  fi
+fi
 
 # ---------------------------------------------------------------------------
 # Create Kind config for 4 nodes (1 control-plane + 3 workers)
@@ -105,55 +154,61 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Build static musl binaries for Kind nodes
+# Install Reaper on all nodes
 # ---------------------------------------------------------------------------
-info "Building Reaper binaries for Kind nodes"
+if $BUILD_MODE; then
+  info "Building Reaper binaries for Kind nodes"
+
+  cd "$REPO_ROOT"
+
+  NODE_ID=$(docker ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.ID}}')
+  NODE_ARCH=$(docker exec "$NODE_ID" uname -m 2>&1) || fail "Cannot detect node architecture"
+
+  case "$NODE_ARCH" in
+    aarch64)
+      TARGET_TRIPLE="aarch64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:aarch64-musl"
+      ;;
+    x86_64)
+      TARGET_TRIPLE="x86_64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:x86_64-musl"
+      ;;
+    *)
+      fail "Unsupported architecture: $NODE_ARCH"
+      ;;
+  esac
+
+  echo "  Architecture: $NODE_ARCH ($TARGET_TRIPLE)"
+
+  docker run --rm \
+    -v "$(pwd)":/work \
+    -w /work \
+    "$MUSL_IMAGE" \
+    cargo build --release \
+      --bin containerd-shim-reaper-v2 \
+      --bin reaper-runtime \
+      --target "$TARGET_TRIPLE" \
+    >> "$LOG_FILE" 2>&1 || {
+      fail "Build failed. See $LOG_FILE for details."
+    }
+
+  mkdir -p target/release
+  cp "target/$TARGET_TRIPLE/release/containerd-shim-reaper-v2" target/release/
+  cp "target/$TARGET_TRIPLE/release/reaper-runtime" target/release/
+
+  ok "Binaries built."
+fi
+
+info "Installing Reaper on all nodes"
 
 cd "$REPO_ROOT"
 
-NODE_ID=$(docker ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.ID}}')
-NODE_ARCH=$(docker exec "$NODE_ID" uname -m 2>&1) || fail "Cannot detect node architecture"
+INSTALL_ARGS=(--kind "$CLUSTER_NAME")
+if ! $BUILD_MODE; then
+  INSTALL_ARGS+=(--release "$RELEASE_VERSION")
+fi
 
-case "$NODE_ARCH" in
-  aarch64)
-    TARGET_TRIPLE="aarch64-unknown-linux-musl"
-    MUSL_IMAGE="messense/rust-musl-cross:aarch64-musl"
-    ;;
-  x86_64)
-    TARGET_TRIPLE="x86_64-unknown-linux-musl"
-    MUSL_IMAGE="messense/rust-musl-cross:x86_64-musl"
-    ;;
-  *)
-    fail "Unsupported architecture: $NODE_ARCH"
-    ;;
-esac
-
-echo "  Architecture: $NODE_ARCH ($TARGET_TRIPLE)"
-
-docker run --rm \
-  -v "$(pwd)":/work \
-  -w /work \
-  "$MUSL_IMAGE" \
-  cargo build --release \
-    --bin containerd-shim-reaper-v2 \
-    --bin reaper-runtime \
-    --target "$TARGET_TRIPLE" \
-  >> "$LOG_FILE" 2>&1 || {
-    fail "Build failed. See $LOG_FILE for details."
-  }
-
-mkdir -p target/release
-cp "target/$TARGET_TRIPLE/release/containerd-shim-reaper-v2" target/release/
-cp "target/$TARGET_TRIPLE/release/reaper-runtime" target/release/
-
-ok "Binaries built."
-
-# ---------------------------------------------------------------------------
-# Install Reaper on all nodes via Ansible
-# ---------------------------------------------------------------------------
-info "Installing Reaper runtime on all nodes"
-
-./scripts/install-reaper.sh --kind "$CLUSTER_NAME" >> "$LOG_FILE" 2>&1 || {
+./scripts/install-reaper.sh "${INSTALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 || {
   fail "Ansible install failed. See $LOG_FILE for details."
 }
 
@@ -265,6 +320,12 @@ echo "${C}========================================${R}"
 echo "${B}Cluster ready: $CLUSTER_NAME${R}"
 echo "${C}========================================${R}"
 echo ""
+
+if ! $BUILD_MODE; then
+  echo "${B}Reaper release: $RELEASE_VERSION${R}"
+else
+  echo "${B}Reaper: built from source${R}"
+fi
 
 echo "${B}Nodes:${R}"
 kubectl get nodes -o custom-columns=\

--- a/examples/05-kubemix/setup.sh
+++ b/examples/05-kubemix/setup.sh
@@ -15,6 +15,7 @@
 # Usage:
 #   ./examples/05-kubemix/setup.sh              # Create cluster (latest release)
 #   ./examples/05-kubemix/setup.sh v0.2.5       # Create cluster (specific release)
+#   ./examples/05-kubemix/setup.sh --build      # Build binaries from source
 #   ./examples/05-kubemix/setup.sh --cleanup    # Delete cluster
 #
 # Prerequisites:
@@ -54,6 +55,24 @@ warn()  { echo " ${Y}!!${R}  $*"; }
 fail()  { echo " ${Y}ERR${R} $*" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  echo "Usage: $0 [VERSION] [OPTIONS]"
+  echo ""
+  echo "Create a 10-node Kind cluster for the kubemix demo."
+  echo ""
+  echo "Arguments:"
+  echo "  VERSION      Release version to install (e.g., v0.2.5). Default: latest"
+  echo ""
+  echo "Options:"
+  echo "  --build      Build binaries from source instead of downloading a release"
+  echo "  --cleanup    Delete the Kind cluster"
+  echo "  -h, --help   Show this help message"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Cleanup mode
 # ---------------------------------------------------------------------------
 if [[ "${1:-}" == "--cleanup" ]]; then
@@ -64,6 +83,17 @@ if [[ "${1:-}" == "--cleanup" ]]; then
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null && ok "Cluster deleted." || warn "Cluster not found."
   exit 0
 fi
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+BUILD_MODE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --build) BUILD_MODE=true ;;
+  esac
+done
 
 # ---------------------------------------------------------------------------
 # Preflight checks
@@ -83,21 +113,29 @@ fi
 ok "All prerequisites found."
 
 # ---------------------------------------------------------------------------
-# Resolve release version
+# Resolve release version (skip when building from source)
 # ---------------------------------------------------------------------------
-# shellcheck source=../../scripts/lib/release-utils.sh
-source "$REPO_ROOT/scripts/lib/release-utils.sh"
+if ! $BUILD_MODE; then
+  # shellcheck source=../../scripts/lib/release-utils.sh
+  source "$REPO_ROOT/scripts/lib/release-utils.sh"
 
-# Accept optional version argument (first non-flag arg)
-RELEASE_VERSION="${1:-latest}"
+  # Accept optional version argument (first non-flag arg)
+  RELEASE_VERSION="latest"
+  for arg in "$@"; do
+    case "$arg" in
+      --build|--cleanup|--help|-h) ;;
+      *) RELEASE_VERSION="$arg" ;;
+    esac
+  done
 
-if [[ "$RELEASE_VERSION" == "latest" ]]; then
-  info "Resolving latest release..."
-  RELEASE_VERSION=$(resolve_latest_release) || \
-    fail "Could not determine latest release. Specify a version: ./examples/05-kubemix/setup.sh v0.2.5"
-  ok "Latest release: $RELEASE_VERSION"
-else
-  ok "Using release: $RELEASE_VERSION"
+  if [[ "$RELEASE_VERSION" == "latest" ]]; then
+    info "Resolving latest release..."
+    RELEASE_VERSION=$(resolve_latest_release) || \
+      fail "Could not determine latest release. Specify a version: ./examples/05-kubemix/setup.sh v0.2.5"
+    ok "Latest release: $RELEASE_VERSION"
+  else
+    ok "Using release: $RELEASE_VERSION"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -136,13 +174,68 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Install Reaper on all nodes via Ansible (pre-built release)
+# Build from source (--build mode)
 # ---------------------------------------------------------------------------
-info "Installing Reaper $RELEASE_VERSION on all nodes (pre-built release)"
+if $BUILD_MODE; then
+  info "Building Reaper binaries for Kind nodes"
+
+  cd "$REPO_ROOT"
+
+  NODE_ID=$(docker ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.ID}}')
+  NODE_ARCH=$(docker exec "$NODE_ID" uname -m 2>&1) || fail "Cannot detect node architecture"
+
+  case "$NODE_ARCH" in
+    aarch64)
+      TARGET_TRIPLE="aarch64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:aarch64-musl"
+      ;;
+    x86_64)
+      TARGET_TRIPLE="x86_64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:x86_64-musl"
+      ;;
+    *)
+      fail "Unsupported architecture: $NODE_ARCH"
+      ;;
+  esac
+
+  echo "  Architecture: $NODE_ARCH ($TARGET_TRIPLE)"
+
+  docker run --rm \
+    -v "$(pwd)":/work \
+    -w /work \
+    "$MUSL_IMAGE" \
+    cargo build --release \
+      --bin containerd-shim-reaper-v2 \
+      --bin reaper-runtime \
+      --target "$TARGET_TRIPLE" \
+    >> "$LOG_FILE" 2>&1 || {
+      fail "Build failed. See $LOG_FILE for details."
+    }
+
+  mkdir -p target/release
+  cp "target/$TARGET_TRIPLE/release/containerd-shim-reaper-v2" target/release/
+  cp "target/$TARGET_TRIPLE/release/reaper-runtime" target/release/
+
+  ok "Binaries built."
+fi
+
+# ---------------------------------------------------------------------------
+# Install Reaper on all nodes via Ansible
+# ---------------------------------------------------------------------------
+if $BUILD_MODE; then
+  info "Installing Reaper on all nodes (built from source)"
+else
+  info "Installing Reaper $RELEASE_VERSION on all nodes (pre-built release)"
+fi
 
 cd "$REPO_ROOT"
 
-./scripts/install-reaper.sh --kind "$CLUSTER_NAME" --release "$RELEASE_VERSION" >> "$LOG_FILE" 2>&1 || {
+INSTALL_ARGS=(--kind "$CLUSTER_NAME")
+if ! $BUILD_MODE; then
+  INSTALL_ARGS+=(--release "$RELEASE_VERSION")
+fi
+
+./scripts/install-reaper.sh "${INSTALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 || {
   fail "Ansible install failed. See $LOG_FILE for details."
 }
 
@@ -253,7 +346,11 @@ kubectl get runtimeclass reaper-v2 &>/dev/null || fail "RuntimeClass reaper-v2 n
 echo ""
 echo "${C}========================================${R}"
 echo "${B}Cluster ready: $CLUSTER_NAME${R}"
-echo "${B}Reaper release: $RELEASE_VERSION${R}"
+if $BUILD_MODE; then
+  echo "${B}Reaper: built from source${R}"
+else
+  echo "${B}Reaper release: $RELEASE_VERSION${R}"
+fi
 echo "${C}========================================${R}"
 echo ""
 

--- a/examples/06-ansible-jobs/setup.sh
+++ b/examples/06-ansible-jobs/setup.sh
@@ -11,6 +11,7 @@
 # Usage:
 #   ./examples/06-ansible-jobs/setup.sh              # Create cluster (latest release)
 #   ./examples/06-ansible-jobs/setup.sh v0.2.5       # Create cluster (specific release)
+#   ./examples/06-ansible-jobs/setup.sh --build      # Build binaries from source
 #   ./examples/06-ansible-jobs/setup.sh --cleanup    # Delete cluster
 #
 # Prerequisites:
@@ -50,6 +51,24 @@ warn()  { echo " ${Y}!!${R}  $*"; }
 fail()  { echo " ${Y}ERR${R} $*" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  echo "Usage: $0 [VERSION] [OPTIONS]"
+  echo ""
+  echo "Create a 3-node Kind cluster for the Ansible jobs demo."
+  echo ""
+  echo "Arguments:"
+  echo "  VERSION      Release version to install (e.g., v0.2.5). Default: latest"
+  echo ""
+  echo "Options:"
+  echo "  --build      Build binaries from source instead of downloading a release"
+  echo "  --cleanup    Delete the Kind cluster"
+  echo "  -h, --help   Show this help message"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Cleanup mode
 # ---------------------------------------------------------------------------
 if [[ "${1:-}" == "--cleanup" ]]; then
@@ -58,6 +77,17 @@ if [[ "${1:-}" == "--cleanup" ]]; then
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null && ok "Cluster deleted." || warn "Cluster not found."
   exit 0
 fi
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+BUILD_MODE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --build) BUILD_MODE=true ;;
+  esac
+done
 
 # ---------------------------------------------------------------------------
 # Preflight checks
@@ -77,21 +107,29 @@ fi
 ok "All prerequisites found."
 
 # ---------------------------------------------------------------------------
-# Resolve release version
+# Resolve release version (skip when building from source)
 # ---------------------------------------------------------------------------
-# shellcheck source=../../scripts/lib/release-utils.sh
-source "$REPO_ROOT/scripts/lib/release-utils.sh"
+if ! $BUILD_MODE; then
+  # shellcheck source=../../scripts/lib/release-utils.sh
+  source "$REPO_ROOT/scripts/lib/release-utils.sh"
 
-# Accept optional version argument (first non-flag arg)
-RELEASE_VERSION="${1:-latest}"
+  # Accept optional version argument (first non-flag arg)
+  RELEASE_VERSION="latest"
+  for arg in "$@"; do
+    case "$arg" in
+      --build|--cleanup|--help|-h) ;;
+      *) RELEASE_VERSION="$arg" ;;
+    esac
+  done
 
-if [[ "$RELEASE_VERSION" == "latest" ]]; then
-  info "Resolving latest release..."
-  RELEASE_VERSION=$(resolve_latest_release) || \
-    fail "Could not determine latest release. Specify a version: ./examples/06-ansible-jobs/setup.sh v0.2.5"
-  ok "Latest release: $RELEASE_VERSION"
-else
-  ok "Using release: $RELEASE_VERSION"
+  if [[ "$RELEASE_VERSION" == "latest" ]]; then
+    info "Resolving latest release..."
+    RELEASE_VERSION=$(resolve_latest_release) || \
+      fail "Could not determine latest release. Specify a version: ./examples/06-ansible-jobs/setup.sh v0.2.5"
+    ok "Latest release: $RELEASE_VERSION"
+  else
+    ok "Using release: $RELEASE_VERSION"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -130,13 +168,68 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Install Reaper on all nodes via Ansible (pre-built release)
+# Build from source (--build mode)
 # ---------------------------------------------------------------------------
-info "Installing Reaper $RELEASE_VERSION on all nodes (pre-built release)"
+if $BUILD_MODE; then
+  info "Building Reaper binaries for Kind nodes"
+
+  cd "$REPO_ROOT"
+
+  NODE_ID=$(docker ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.ID}}')
+  NODE_ARCH=$(docker exec "$NODE_ID" uname -m 2>&1) || fail "Cannot detect node architecture"
+
+  case "$NODE_ARCH" in
+    aarch64)
+      TARGET_TRIPLE="aarch64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:aarch64-musl"
+      ;;
+    x86_64)
+      TARGET_TRIPLE="x86_64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:x86_64-musl"
+      ;;
+    *)
+      fail "Unsupported architecture: $NODE_ARCH"
+      ;;
+  esac
+
+  echo "  Architecture: $NODE_ARCH ($TARGET_TRIPLE)"
+
+  docker run --rm \
+    -v "$(pwd)":/work \
+    -w /work \
+    "$MUSL_IMAGE" \
+    cargo build --release \
+      --bin containerd-shim-reaper-v2 \
+      --bin reaper-runtime \
+      --target "$TARGET_TRIPLE" \
+    >> "$LOG_FILE" 2>&1 || {
+      fail "Build failed. See $LOG_FILE for details."
+    }
+
+  mkdir -p target/release
+  cp "target/$TARGET_TRIPLE/release/containerd-shim-reaper-v2" target/release/
+  cp "target/$TARGET_TRIPLE/release/reaper-runtime" target/release/
+
+  ok "Binaries built."
+fi
+
+# ---------------------------------------------------------------------------
+# Install Reaper on all nodes via Ansible
+# ---------------------------------------------------------------------------
+if $BUILD_MODE; then
+  info "Installing Reaper on all nodes (built from source)"
+else
+  info "Installing Reaper $RELEASE_VERSION on all nodes (pre-built release)"
+fi
 
 cd "$REPO_ROOT"
 
-./scripts/install-reaper.sh --kind "$CLUSTER_NAME" --release "$RELEASE_VERSION" >> "$LOG_FILE" 2>&1 || {
+INSTALL_ARGS=(--kind "$CLUSTER_NAME")
+if ! $BUILD_MODE; then
+  INSTALL_ARGS+=(--release "$RELEASE_VERSION")
+fi
+
+./scripts/install-reaper.sh "${INSTALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 || {
   fail "Ansible install failed. See $LOG_FILE for details."
 }
 
@@ -187,7 +280,11 @@ WORKERS=($(kubectl get nodes --no-headers -o custom-columns=NAME:.metadata.name 
 echo ""
 echo "${C}========================================${R}"
 echo "${B}Cluster ready: $CLUSTER_NAME${R}"
-echo "${B}Reaper release: $RELEASE_VERSION${R}"
+if $BUILD_MODE; then
+  echo "${B}Reaper: built from source${R}"
+else
+  echo "${B}Reaper release: $RELEASE_VERSION${R}"
+fi
 echo "${C}========================================${R}"
 echo ""
 

--- a/examples/08-mix-container-runtime-engines/README.md
+++ b/examples/08-mix-container-runtime-engines/README.md
@@ -12,7 +12,7 @@ This is the first example showing Reaper workloads consuming a service from a tr
 | Service consumption | Reaper workloads reach a ClusterIP service via kube-proxy iptables |
 | Host-level system changes | SSSD packages, config files, and daemon installed on each node via overlay |
 | Dependency ordering | Init containers poll for Ansible availability and LDAP connectivity |
-| Fixed ClusterIP | Avoids DNS — Reaper pods use host networking, not CoreDNS |
+| Kubernetes DNS | Reaper pods resolve services via CoreDNS (REAPER_DNS_MODE=kubernetes) |
 
 ## Topology
 
@@ -66,7 +66,7 @@ base-deps DaemonSet starts (Reaper, all 3 workers)
 
 base-config DaemonSet starts (Reaper, all 3 workers)
   ├── Init 1: wait-for-ansible → polls until ansible-playbook found (up to 300s)
-  ├── Init 2: wait-for-ldap → polls TCP 10.96.100.100:389 (up to 300s)
+  ├── Init 2: wait-for-ldap → resolves openldap DNS + polls TCP (up to 300s)
   └── Main: ansible-playbook → install SSSD → configure → start → verify → sleep
 ```
 

--- a/examples/08-mix-container-runtime-engines/base-config-daemonset.yaml
+++ b/examples/08-mix-container-runtime-engines/base-config-daemonset.yaml
@@ -60,9 +60,9 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              echo "Waiting for OpenLDAP service at 10.96.100.100:389..."
+              echo "Waiting for OpenLDAP service at openldap:389..."
               ATTEMPTS=0
-              until bash -c "echo > /dev/tcp/10.96.100.100/389" 2>/dev/null; do
+              until getent hosts openldap >/dev/null 2>&1 && bash -c "echo > /dev/tcp/openldap/389" 2>/dev/null; do
                 ATTEMPTS=$((ATTEMPTS + 1))
                 if [ $ATTEMPTS -ge 60 ]; then
                   echo "ERROR: Timed out after 300s waiting for OpenLDAP"
@@ -70,7 +70,7 @@ spec:
                 fi
                 sleep 5
               done
-              echo "OpenLDAP is reachable at 10.96.100.100:389"
+              echo "OpenLDAP is reachable at openldap:389"
 
       containers:
         - name: playbook-runner

--- a/examples/08-mix-container-runtime-engines/base-config-playbook.ansible
+++ b/examples/08-mix-container-runtime-engines/base-config-playbook.ansible
@@ -36,7 +36,7 @@
           [domain/reaper.local]
           id_provider = ldap
           auth_provider = ldap
-          ldap_uri = ldap://10.96.100.100:389
+          ldap_uri = ldap://openldap.default.svc.cluster.local:389
           ldap_search_base = dc=reaper,dc=local
           ldap_default_bind_dn = cn=admin,dc=reaper,dc=local
           ldap_default_authtok = adminpassword

--- a/examples/08-mix-container-runtime-engines/openldap.yaml
+++ b/examples/08-mix-container-runtime-engines/openldap.yaml
@@ -6,7 +6,7 @@
 # Three resources:
 #   1. ConfigMap with bootstrap LDIF (users and groups)
 #   2. Deployment with osixia/openldap + ldap-seeder sidecar
-#   3. Service with fixed ClusterIP (Reaper pods can't resolve DNS)
+#   3. Service (Reaper pods resolve it via Kubernetes DNS with REAPER_DNS_MODE=kubernetes)
 #
 # The main container runs OpenLDAP. A sidecar container waits for LDAP
 # to be ready, then loads the custom LDIF with ldapadd -c (idempotent).
@@ -217,11 +217,10 @@ metadata:
     app: openldap
 spec:
   type: ClusterIP
-  # Fixed ClusterIP for predictability. Reaper workloads run with host
-  # networking and can reach ClusterIPs (kube-proxy iptables), but cannot
-  # resolve Kubernetes DNS names (the node's /etc/resolv.conf doesn't
-  # point to CoreDNS). A fixed IP avoids DNS-based service discovery.
-  clusterIP: 10.96.100.100
+  # Reaper workloads resolve this service via Kubernetes DNS when
+  # REAPER_DNS_MODE=kubernetes (the default for Ansible-deployed clusters).
+  # The kubelet-prepared resolv.conf is written into the overlay, pointing
+  # to CoreDNS for service name resolution.
   selector:
     app: openldap
   ports:

--- a/examples/08-mix-container-runtime-engines/setup.sh
+++ b/examples/08-mix-container-runtime-engines/setup.sh
@@ -13,6 +13,7 @@
 # Usage:
 #   ./examples/08-mix-container-runtime-engines/setup.sh              # Create cluster (latest release)
 #   ./examples/08-mix-container-runtime-engines/setup.sh v0.2.5       # Create cluster (specific release)
+#   ./examples/08-mix-container-runtime-engines/setup.sh --build      # Build binaries from source
 #   ./examples/08-mix-container-runtime-engines/setup.sh --cleanup    # Delete cluster
 #
 # Prerequisites:
@@ -52,6 +53,24 @@ warn()  { echo " ${Y}!!${R}  $*"; }
 fail()  { echo " ${Y}ERR${R} $*" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  echo "Usage: $0 [VERSION] [OPTIONS]"
+  echo ""
+  echo "Create a 4-node Kind cluster for the mixed runtime demo."
+  echo ""
+  echo "Arguments:"
+  echo "  VERSION      Release version to install (e.g., v0.2.5). Default: latest"
+  echo ""
+  echo "Options:"
+  echo "  --build      Build binaries from source instead of downloading a release"
+  echo "  --cleanup    Delete the Kind cluster"
+  echo "  -h, --help   Show this help message"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Cleanup mode
 # ---------------------------------------------------------------------------
 if [[ "${1:-}" == "--cleanup" ]]; then
@@ -60,6 +79,17 @@ if [[ "${1:-}" == "--cleanup" ]]; then
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null && ok "Cluster deleted." || warn "Cluster not found."
   exit 0
 fi
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+BUILD_MODE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --build) BUILD_MODE=true ;;
+  esac
+done
 
 # ---------------------------------------------------------------------------
 # Preflight checks
@@ -79,21 +109,29 @@ fi
 ok "All prerequisites found."
 
 # ---------------------------------------------------------------------------
-# Resolve release version
+# Resolve release version (skip when building from source)
 # ---------------------------------------------------------------------------
-# shellcheck source=../../scripts/lib/release-utils.sh
-source "$REPO_ROOT/scripts/lib/release-utils.sh"
+if ! $BUILD_MODE; then
+  # shellcheck source=../../scripts/lib/release-utils.sh
+  source "$REPO_ROOT/scripts/lib/release-utils.sh"
 
-# Accept optional version argument (first non-flag arg)
-RELEASE_VERSION="${1:-latest}"
+  # Accept optional version argument (first non-flag arg)
+  RELEASE_VERSION="latest"
+  for arg in "$@"; do
+    case "$arg" in
+      --build|--cleanup|--help|-h) ;;
+      *) RELEASE_VERSION="$arg" ;;
+    esac
+  done
 
-if [[ "$RELEASE_VERSION" == "latest" ]]; then
-  info "Resolving latest release..."
-  RELEASE_VERSION=$(resolve_latest_release) || \
-    fail "Could not determine latest release. Specify a version: ./examples/08-mix-container-runtime-engines/setup.sh v0.2.5"
-  ok "Latest release: $RELEASE_VERSION"
-else
-  ok "Using release: $RELEASE_VERSION"
+  if [[ "$RELEASE_VERSION" == "latest" ]]; then
+    info "Resolving latest release..."
+    RELEASE_VERSION=$(resolve_latest_release) || \
+      fail "Could not determine latest release. Specify a version: ./examples/08-mix-container-runtime-engines/setup.sh v0.2.5"
+    ok "Latest release: $RELEASE_VERSION"
+  else
+    ok "Using release: $RELEASE_VERSION"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -126,13 +164,68 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Install Reaper on all nodes via Ansible (pre-built release)
+# Build from source (--build mode)
 # ---------------------------------------------------------------------------
-info "Installing Reaper $RELEASE_VERSION on all nodes (pre-built release)"
+if $BUILD_MODE; then
+  info "Building Reaper binaries for Kind nodes"
+
+  cd "$REPO_ROOT"
+
+  NODE_ID=$(docker ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.ID}}')
+  NODE_ARCH=$(docker exec "$NODE_ID" uname -m 2>&1) || fail "Cannot detect node architecture"
+
+  case "$NODE_ARCH" in
+    aarch64)
+      TARGET_TRIPLE="aarch64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:aarch64-musl"
+      ;;
+    x86_64)
+      TARGET_TRIPLE="x86_64-unknown-linux-musl"
+      MUSL_IMAGE="messense/rust-musl-cross:x86_64-musl"
+      ;;
+    *)
+      fail "Unsupported architecture: $NODE_ARCH"
+      ;;
+  esac
+
+  echo "  Architecture: $NODE_ARCH ($TARGET_TRIPLE)"
+
+  docker run --rm \
+    -v "$(pwd)":/work \
+    -w /work \
+    "$MUSL_IMAGE" \
+    cargo build --release \
+      --bin containerd-shim-reaper-v2 \
+      --bin reaper-runtime \
+      --target "$TARGET_TRIPLE" \
+    >> "$LOG_FILE" 2>&1 || {
+      fail "Build failed. See $LOG_FILE for details."
+    }
+
+  mkdir -p target/release
+  cp "target/$TARGET_TRIPLE/release/containerd-shim-reaper-v2" target/release/
+  cp "target/$TARGET_TRIPLE/release/reaper-runtime" target/release/
+
+  ok "Binaries built."
+fi
+
+# ---------------------------------------------------------------------------
+# Install Reaper on all nodes via Ansible
+# ---------------------------------------------------------------------------
+if $BUILD_MODE; then
+  info "Installing Reaper on all nodes (built from source)"
+else
+  info "Installing Reaper $RELEASE_VERSION on all nodes (pre-built release)"
+fi
 
 cd "$REPO_ROOT"
 
-./scripts/install-reaper.sh --kind "$CLUSTER_NAME" --release "$RELEASE_VERSION" >> "$LOG_FILE" 2>&1 || {
+INSTALL_ARGS=(--kind "$CLUSTER_NAME")
+if ! $BUILD_MODE; then
+  INSTALL_ARGS+=(--release "$RELEASE_VERSION")
+fi
+
+./scripts/install-reaper.sh "${INSTALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 || {
   fail "Ansible install failed. See $LOG_FILE for details."
 }
 
@@ -202,7 +295,11 @@ kubectl get runtimeclass reaper-v2 &>/dev/null || fail "RuntimeClass reaper-v2 n
 echo ""
 echo "${C}========================================${R}"
 echo "${B}Cluster ready: $CLUSTER_NAME${R}"
-echo "${B}Reaper release: $RELEASE_VERSION${R}"
+if $BUILD_MODE; then
+  echo "${B}Reaper: built from source${R}"
+else
+  echo "${B}Reaper release: $RELEASE_VERSION${R}"
+fi
 echo "${C}========================================${R}"
 echo ""
 
@@ -221,6 +318,10 @@ echo "  ${G}compute${R} (workers 1-2) ←  SSSD only (Reaper)"
 echo ""
 echo "${B}ConfigMaps:${R}"
 echo "  base-config-playbook   (Ansible playbook for SSSD configuration)"
+
+echo ""
+echo "${B}DNS Mode:${R}"
+echo "  REAPER_DNS_MODE=kubernetes (Reaper pods resolve Kubernetes service names via CoreDNS)"
 
 echo ""
 echo "${B}RuntimeClass:${R}"


### PR DESCRIPTION
## Summary

- **Kubernetes DNS resolution for Reaper pods**: New `REAPER_DNS_MODE` env var (`kubernetes`/`k8s`) writes the kubelet-prepared resolv.conf into the overlay namespace, enabling Reaper workloads to resolve Kubernetes service names (e.g., `my-svc.default.svc.cluster.local`) via CoreDNS
- **Unified example setup scripts**: All 8 example `setup.sh` scripts now default to downloading published release binaries, with a `--build` flag for source compilation. Added `--help`/`-h` to all scripts.
- **Example 08 updated**: Replaced hardcoded `clusterIP: 10.96.100.100` with DNS-based service discovery, demonstrating the new DNS feature

## Changes

### Core (`overlay.rs`, `main.rs`)
- `DnsMode` enum + `read_dns_config()` reads `REAPER_DNS_MODE` env var
- `apply_kubernetes_dns()` finds `/etc/resolv.conf` OCI mount, reads content via `/proc/1/root/<source>`, writes it into the overlay
- Called from `do_start()` after volume mounts, before workload spawn
- DNS failure is fatal when explicitly opted-in (misconfiguration should not silently fall back)

### Ansible (`install-reaper.yml`)
- Adds `REAPER_DNS_MODE=kubernetes` to `/etc/default/containerd` (default for Ansible-deployed clusters)

### Integration tests
- New `test_kubernetes_dns_resolution()` verifying Reaper pods can resolve `kubernetes.default.svc.cluster.local` and a custom ClusterIP service

### Examples (01-08)
- All `setup.sh` scripts: added `--help`, `--build`, release version resolution via `scripts/lib/release-utils.sh`
- Example 08: DNS-based LDAP service discovery instead of hardcoded ClusterIP

## Test plan

- [x] `cargo test` — unit tests pass (DNS config parsing)
- [x] `cargo clippy --target x86_64-unknown-linux-gnu --all-targets` — clean
- [x] `bash -n` syntax check on all 8 setup.sh scripts
- [x] `./scripts/run-integration-tests.sh` — full suite including new `test_kubernetes_dns_resolution`
- [x] Manual: run example 08 with `--build` flag, verify `getent passwd user1` resolves via DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)