### PR TITLE
fix: serialize config unit tests to prevent CI race

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -55,9 +55,11 @@ pub fn load_config() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::io::Write;
 
     #[test]
+    #[serial]
     fn test_load_config_missing_file() {
         // Should not panic when file doesn't exist
         std::env::set_var("REAPER_CONFIG", "/nonexistent/path/reaper.conf");
@@ -66,6 +68,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_load_config_parses_values() {
         let dir = tempfile::tempdir().unwrap();
         let conf = dir.path().join("reaper.conf");
@@ -96,6 +99,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_env_var_takes_precedence() {
         let dir = tempfile::tempdir().unwrap();
         let conf = dir.path().join("reaper.conf");
@@ -117,6 +121,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_skips_malformed_lines() {
         let dir = tempfile::tempdir().unwrap();
         let conf = dir.path().join("reaper.conf");


### PR DESCRIPTION
## Summary

- Fix test parallelism race in `config::tests` that caused CI coverage failures
- The config tests mutate the shared `REAPER_CONFIG` env var; without serialization, parallel test threads race on `set_var`/`remove_var`, causing intermittent `NotPresent` panics
- Add `#[serial]` attribute (from `serial_test` crate, already a dev-dependency) to all 4 config tests

## Test plan

- [x] `cargo test config::tests` — 8/8 pass (4 per binary)
- [x] `cargo clippy --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)