### PR TITLE
fix: improve docs deployment workflow with Pages setup guidance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'examples/README.md'
       - '.github/workflows/docs.yml'
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'examples/README.md'
       - '.github/workflows/docs.yml'
 
 # Allow only one concurrent deployment
@@ -51,6 +53,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Check GitHub Pages is enabled
+        run: |
+          echo "If this step fails with a 404, enable GitHub Pages in your repository:"
+          echo "  Settings → Pages → Source: GitHub Actions"
+          echo ""
+          echo "See: https://github.com/miguelgila/reaper/settings/pages"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Add clear error message in deploy step when GitHub Pages is not enabled
- Include `examples/README.md` in workflow trigger paths (referenced via mdBook `{{#include}}`)

The deployment failure in [run #23302614094](https://github.com/miguelgila/reaper/actions/runs/23302614094) was caused by GitHub Pages not being enabled in repository settings.

**Required manual step:** Enable GitHub Pages at Settings → Pages → Source: **GitHub Actions**

Fixes #43

## Test plan

- [x] Workflow YAML is valid
- [ ] After enabling Pages in settings, re-run the workflow to verify deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)