### PR TITLE
chore: make Linux the default clippy target

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,8 +6,9 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR" || exit 0
 
 if command -v cargo >/dev/null 2>&1; then
-  echo "Running cargo clippy -- -D warnings..."
-  cargo clippy -- -D warnings
+  LINUX_TARGET="x86_64-unknown-linux-gnu"
+  echo "Running cargo clippy --target $LINUX_TARGET --all-targets -- -D warnings..."
+  cargo clippy --target "$LINUX_TARGET" --all-targets -- -D warnings
 else
   echo "cargo not found in PATH; skipping clippy."
 fi

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LINUX_TARGET := x86_64-unknown-linux-gnu
 DOCKER_IMAGE := reaper-dev
 COVERAGE_VOL := reaper-cargo-cache
 
-.PHONY: help build test fmt clippy check-linux coverage ci clean docs docs-serve
+.PHONY: help build test fmt clippy clippy-local coverage ci clean docs docs-serve
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -17,10 +17,10 @@ help: ## Show this help
 # Build
 # ---------------------------------------------------------------------------
 
-build: ## Build debug binaries (macOS native)
+build: ## Build debug binaries (native)
 	cargo build
 
-build-release: ## Build release binaries (macOS native)
+build-release: ## Build release binaries (native)
 	cargo build --release
 
 # ---------------------------------------------------------------------------
@@ -30,17 +30,17 @@ build-release: ## Build release binaries (macOS native)
 fmt: ## Check formatting (fails if unformatted)
 	cargo fmt -- --check
 
-clippy: ## Run clippy for macOS target
-	cargo clippy -- -D warnings
-
-check-linux: ## Cross-check clippy for Linux target (catches cfg(linux) issues)
+clippy: ## Run clippy for Linux target (authoritative — catches all cfg(linux) code)
 	cargo clippy --target $(LINUX_TARGET) --all-targets -- -D warnings
+
+clippy-local: ## Run clippy for local (macOS) target (fast, but skips Linux-only code)
+	cargo clippy -- -D warnings
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
-test: ## Run all unit and integration tests (macOS native)
+test: ## Run all unit and integration tests
 	cargo test --verbose
 
 test-unit: ## Run only unit tests for reaper-runtime
@@ -72,7 +72,7 @@ coverage: ## Run tarpaulin in Docker (same as CI, with caching)
 # CI — run everything GitHub Actions runs (except kind integration)
 # ---------------------------------------------------------------------------
 
-ci: fmt clippy check-linux test coverage ## Full CI-equivalent check (format + clippy + linux check + tests + coverage)
+ci: fmt clippy test coverage ## Full CI-equivalent check (format + clippy + tests + coverage)
 	@echo ""
 	@echo "All CI checks passed."
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -134,29 +134,24 @@ cargo fmt --all -- --check
 
 ### Linting
 
-Run clippy to catch common mistakes and improve code quality:
+Reaper only runs on Linux and large portions of the codebase are gated behind `#[cfg(target_os = "linux")]`. **Always lint against the Linux target** — macOS clippy silently skips Linux-only code and gives false confidence:
 
 ```bash
-# Quick check
-cargo clippy --all-targets --all-features
+# Authoritative check (use this — catches all Linux-gated code)
+make clippy
+# equivalent to: cargo clippy --target x86_64-unknown-linux-gnu --all-targets -- -D warnings
 
-# Match CI exactly (treats warnings as errors)
-cargo clippy -- -D warnings
+# One-time setup for Linux cross-check on macOS
+rustup target add x86_64-unknown-linux-gnu
+```
+
+For a faster iteration cycle that only checks macOS-compiled code (does **not** replace the Linux check):
+
+```bash
+make clippy-local
 ```
 
 CI runs clippy with `-D warnings`, so any warning is a hard failure. The pre-push hook runs this automatically if you've installed hooks via `./scripts/install-hooks.sh`.
-
-### Linux Cross-Check (macOS only)
-
-The overlay module (`src/bin/reaper-runtime/overlay.rs`) is gated by `#[cfg(target_os = "linux")]` and doesn't compile on macOS. To catch compilation errors in Linux-only code:
-
-```bash
-# One-time setup
-rustup target add x86_64-unknown-linux-gnu
-
-# Check compilation for Linux target
-cargo clippy --target x86_64-unknown-linux-gnu --all-targets --all-features
-```
 
 ## Git Hooks
 
@@ -258,9 +253,9 @@ Configuration lives in `tarpaulin.toml`. Functions requiring root + Linux namesp
    cargo fmt --all
    ```
 
-2. **Run linting:**
+2. **Run linting (Linux target):**
    ```bash
-   cargo clippy --all-targets --all-features
+   make clippy
    ```
 
 3. **Run tests:**
@@ -285,7 +280,7 @@ For fast feedback during development:
 ```bash
 # Quick iteration cycle
 cargo test              # Unit tests (seconds)
-cargo clippy            # Linting
+make clippy             # Linting (Linux target)
 
 # Before pushing
 cargo fmt --all         # Format code
@@ -396,12 +391,9 @@ RUST_LOG=debug cargo test <test-name> -- --nocapture
 
 ## Troubleshooting
 
-### Clippy Errors on macOS for Linux-only Code
+### Clippy Errors in Linux-only Code
 
-Run clippy with Linux target:
-```bash
-cargo clippy --target x86_64-unknown-linux-gnu --all-targets
-```
+The default `make clippy` targets Linux. If you see errors in `#[cfg(target_os = "linux")]` code, that's expected — fix them before pushing. Running `make clippy-local` will skip these, but is **not** a substitute.
 
 ### Tests Fail with "Permission Denied"
 


### PR DESCRIPTION
## Summary
- `make clippy` now targets `x86_64-unknown-linux-gnu` by default — the authoritative check that catches all `#[cfg(target_os = "linux")]` code
- `make clippy-local` added for fast macOS-only iteration (with clear caveat)
- Pre-push git hook updated to lint against Linux target
- DEVELOPMENT.md rewritten to emphasize Linux-first linting workflow

Closes #59

## Test plan
- [x] `make help` shows updated target descriptions
- [x] `make clippy` runs Linux cross-check
- [x] Pre-push hook runs Linux clippy (verified on push)
- [x] mdBook builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)