### PR TITLE
ci: eliminate duplicate CI runs on PR merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "fix/**"]
+    branches: ["fix/**"]
     paths-ignore:
       - "**/*.md"
       - "docs/**"


### PR DESCRIPTION
## Summary

Remove `main` from the `push` trigger in `ci.yml`. PR merges were triggering CI twice — once on the `pull_request` event (during review) and again on the `push` event (merge commit on main). The second run tests identical code.

One-line change: `branches: [main, "fix/**"]` → `branches: ["fix/**"]`

## Impact

- PR CI runs: unchanged (still triggered by `pull_request`)
- Direct pushes to main: no longer trigger CI (enforces PR workflow)
- Hotfix branches (`fix/**`): still trigger CI on push
- Auto-release `[skip ci]` commits: unaffected (already skipped)

## Test plan

- [ ] This PR itself should trigger CI once (via `pull_request`), not twice
- [ ] After merge, no `push`-triggered CI run on main

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)